### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Reusable Security Workflow
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/47](https://github.com/flamingquaks/promptrek/security/code-scanning/47)

The problem should be fixed by specifying an explicit `permissions:` block in the workflow YAML. This can be done at the root of the workflow to apply to all jobs (unless overridden by job-level permissions), or at each job individually if different jobs require different levels of access. For this case, a root-level block is sufficient, and the minimal permission needed is typically `contents: read`, since the jobs only require reading the repository contents (for checkout) and uploading artifacts—they do not push code, interact with issues or pull requests, nor do they perform deployment tasks.

To implement, add the following lines immediately after the `name:` line (at the top of the file):

```yaml
permissions:
  contents: read
```

No other files or changes are required. No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
