### PR TITLE
Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Reusable Test Workflow
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/46](https://github.com/flamingquaks/promptrek/security/code-scanning/46)

To resolve the problem, you should explicitly assign the least privilege necessary to the GITHUB_TOKEN in your workflow. The recommended approach is to add a `permissions` block at the workflow root, because currently no jobs have their own permissions, and the workflow only has one job. In this workflow, most tasks only need to read the repository contents; the only exception is the Codecov upload step, which may require access to the `contents: read` permission and possibly additional permission for uploading coverage. The minimal recommended permissions block is:

```yaml
permissions:
  contents: read
```

However, if you want to allow uploading coverage reports to Codecov, according to [Codecov docs](https://github.com/codecov/codecov-action), this only requires `contents: read`. No additional upload/write permissions are needed for Codecov in most typical usage. Add the permissions block immediately after the `name:` key (before `on:`). No other changes are needed, and this does not break existing functionality.  

Edit `.github/workflows/test.yml` as follows:
- Add a new block:  
  ```yaml
  permissions:
    contents: read
  ```
  after `name: Reusable Test Workflow`
- No need to add job-level permissions, since there is only one job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
