### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -175,6 +175,8 @@ jobs:
   # Documentation validation
   docs-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/45](https://github.com/flamingquaks/promptrek/security/code-scanning/45)

To fix the problem, add a minimal `permissions` block to the `docs-check` job in `.github/workflows/pr.yml`. Place this block immediately below `runs-on: ubuntu-latest` for the `docs-check` job, since that is the affected region highlighted by CodeQL. Set `contents: read`, which is sufficient for jobs that need to check out repository code but not push, modify, or create content. No import or other changes are required for this YAML fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
