### PR TITLE
Potential fix for code scanning alert no. 44: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,6 +137,8 @@ jobs:
   cli-test:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/44](https://github.com/flamingquaks/promptrek/security/code-scanning/44)

To fix this problem, we should add an explicit `permissions` block to the `cli-test` job in the `.github/workflows/pr.yml` workflow. Since the `cli-test` job only installs artifacts and runs CLI commands without needing to modify the repository or PR (i.e., it does not post comments or modify content), it requires only `contents: read` permissions—the minimum necessary for typical read-only tasks. This block should be added directly under the `cli-test:` job definition (right after its `runs-on: ubuntu-latest` or before the `steps:` key). This change does not affect existing functionality but explicitly restricts the job’s token permissions, improving security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
