### PR TITLE
Potential fix for code scanning alert no. 42: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/42](https://github.com/flamingquaks/promptrek/security/code-scanning/42)

To fix this issue, explicitly specify the minimal required `permissions:` at the top level of the workflow (directly below the workflow name and triggers, before `jobs:`). For typical CI workflows that only require cloning code and running tests, `contents: read` is usually sufficient. Only add broader permissions (e.g., `pull-requests: write`) if needed for specific actions performed by jobs (not shown in the code provided).  
Edit `.github/workflows/ci.yml`, and add a block like:

```yaml
permissions:
  contents: read
```
...after the workflow `name:` and before `jobs:`. This will restrict the GITHUB_TOKEN permissions for all jobs in the workflow unless overridden in specific jobs.

If future jobs require additional permissions (e.g., uploading releases, commenting on PRs), extend the block appropriately.  
No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
