### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/41](https://github.com/flamingquaks/promptrek/security/code-scanning/41)

To fix the issue, add an explicit `permissions` block to the root of the workflow in `.github/workflows/ci.yml`, ensuring all jobs use the least privilege required. As a general starting point, set most access to read-only, e.g., `contents: read`. If jobs require specific write accesses (e.g., to pull requests, issues, etc.), these can be added as needed later at either the root or per-job level. For a typical CI pipeline, read-only access is usually sufficient unless you are, for example, auto-updating PRs or creating releases. The permissions should be added just after the workflow `name` and before the `on:` block (conventionally), applying to the whole workflow.

**Where to change:**  
- File: `.github/workflows/ci.yml`
- Region: Add `permissions` after `name:` and before `on:` (lines 1–2).

**What's needed:**  
- No new imports, methods, or definitions.
- The block should be:
  ```yaml
  permissions:
    contents: read
  ```
  This limits the token to read-only access to repository contents. Other write permissions can be added later if needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
