### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: Nightly Tests
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/40](https://github.com/flamingquaks/promptrek/security/code-scanning/40)

To fix the issue, explicitly set a `permissions` block in the workflow file to limit the GITHUB_TOKEN to only the minimum needed rights. In this case, none of the jobs need to perform any write actions to repository contents, issues, or pull requests, so assigning only `contents: read` is appropriate. This block should be added to the root of the workflow, just after the workflow `name:` and before `on:`. This will apply to all jobs unless any of them require broader permissions, in which case a job-specific override can be applied.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
