### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -200,6 +200,9 @@ jobs:
     needs: [build, test-fast, code-quality, security, cli-test, docs-check]
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: PR Validation Summary


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/28](https://github.com/flamingquaks/promptrek/security/code-scanning/28)

To fix this issue, explicitly declare the minimal required permissions for the `pr-status` job in `.github/workflows/pr.yml`. Alternatively, a top-level workflow `permissions` block could be set, but per-job is more precise here. The `pr-status` job only needs to comment on pull requests (requires `pull-requests: write`) and may need `contents: read` for minimal operation. The addition should go at the same indentation level as `needs:` in the `pr-status` job (just below line 201). No other code or files need to be changed. GitHub Actions will now restrict the job's token to only those explicit permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
