### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,6 +127,8 @@ jobs:
 
   # Security scan for PRs
   security:
+    permissions:
+      contents: read
     uses: ./.github/workflows/security.yml
     with:
       python-version: "3.11"


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/22](https://github.com/flamingquaks/promptrek/security/code-scanning/22)

To resolve this issue, explicitly set the minimum required permissions for the `security` job in `.github/workflows/pr.yml`. Since the actual job is running a security scan (likely reading code and reporting findings), it almost certainly does not need write access. The least-privilege default for a security scan is `contents: read`. The fix is to add a `permissions` block to the `security` job (line 130), with `contents: read` as the starting point. If, upon inspection of `.github/workflows/security.yml`, it turns out to require other permissions (such as opening issues or commenting on PRs), those could be added, but with just the current context, a minimal set is best.

Implementation steps:
- In `.github/workflows/pr.yml`, under the `security` job (immediately before or after `uses: ./.github/workflows/security.yml`), add:
  ```
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
