### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
   # Fast tests on primary platform
   test-fast:
     needs: build
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
     with:
       python-version: "3.11"


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/14](https://github.com/flamingquaks/promptrek/security/code-scanning/14)

To fix this problem, you should add an explicit `permissions` block to the `test-fast` job in `.github/workflows/pr.yml`, specifying the minimum required permissions. Since the job runs tests and collects coverage, it likely only needs read access to the repository contents. Unless the downstream workflow in `test.yml` requires write access (not shown), the safest default is `contents: read`.

Edit `.github/workflows/pr.yml` by adding the following block within the `test-fast` job, just after the `needs: build` line or before the `uses: ./.github/workflows/test.yml` line:
```yaml
permissions:
  contents: read
```
This restricts actions executed in the `test-fast` job to minimal privileges, satisfying the CodeQL requirement and adhering to least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
