### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   # Quick build check
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
     with:
       python-version: "3.11"


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/11](https://github.com/flamingquaks/promptrek/security/code-scanning/11)

To fix the flagged issue, add an explicit `permissions` block for the `build` job in `.github/workflows/pr.yml`. This ensures that the job only receives the minimal permissions needed for its execution. Since the job delegates to `./.github/workflows/build.yml` and is a typical build step, it usually only needs `contents: read` access. Update the `build` job definition to insert the block directly beneath the job name (line 14).

This change affects lines 14-19 in the workflow file. No additional files or library dependencies are required; only a YAML key needs to be added. If, upon reviewing the reusable workflow, it turns out that more permissions are required, they can be expanded accordingly, but the best default is `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
