### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Reusable Build Workflow
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/flamingquaks/promptrek/security/code-scanning/4](https://github.com/flamingquaks/promptrek/security/code-scanning/4)

To fix this problem, an explicit `permissions` block should be added to the workflow. The block can be added either at the root level (globally for all jobs in the workflow) or at the job level for `build`. As this workflow mainly reads code and uploads artifacts but does not push changes or manipulate PRs, only the minimal necessary permissions should be granted. The absolute minimal starting point is `contents: read`, but if artifact uploading or any action requires more than just read permission (it does not in this scenario), additional granular permissions can be added.

The recommended change is to add the following block **at the top level of the workflow file**, right after the workflow `name` and before `on`, to grant the minimal necessary permissions (`contents: read`). No additional imports, methods, or changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
