### PR TITLE
fix: Add Claude-specific patterns to .gitignore and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,9 @@ test-project/
 .kiro/steering/*.md
 .tabnine_commands
 .vscode/mcp.json
+
+# PrompTrek editor-specific files (generated, not committed)
+.claude/commands/*.md
+.claude/agents/*.md
+.claude/hooks.yaml
+.mcp.json

--- a/src/promptrek/utils/gitignore.py
+++ b/src/promptrek/utils/gitignore.py
@@ -38,6 +38,10 @@ def get_editor_file_patterns() -> List[str]:
         # Claude
         ".claude/CLAUDE.md",
         ".claude-context.md",
+        ".claude/commands/*.md",
+        ".claude/agents/*.md",
+        ".claude/hooks.yaml",
+        ".mcp.json",
         # Amazon Q
         ".amazonq/rules/*.md",
         ".amazonq/cli-agents/*.json",

--- a/tests/unit/test_gitignore.py
+++ b/tests/unit/test_gitignore.py
@@ -37,6 +37,18 @@ class TestGetEditorFilePatterns:
         assert ".windsurf/rules/*.md" in patterns
         assert ".clinerules" in patterns
 
+    def test_includes_claude_patterns(self):
+        """Should include all Claude-specific patterns."""
+        patterns = get_editor_file_patterns()
+
+        # Check for Claude patterns
+        assert ".claude/CLAUDE.md" in patterns
+        assert ".claude-context.md" in patterns
+        assert ".claude/commands/*.md" in patterns
+        assert ".claude/agents/*.md" in patterns
+        assert ".claude/hooks.yaml" in patterns
+        assert ".mcp.json" in patterns
+
 
 class TestReadGitignore:
     """Tests for read_gitignore function."""


### PR DESCRIPTION
Introduce patterns for Claude-specific files in the .gitignore and add corresponding tests to ensure these patterns are included correctly.