### PR TITLE
CI: Configure GitHub Labels and Action

### DIFF
--- a/.github/scripts/determine_labels.py
+++ b/.github/scripts/determine_labels.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Determine which editor labels should be applied to a PR based on changed files.
+
+This script analyzes the list of changed files and maps them to editor labels.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Set
+
+
+# Mapping of file patterns to editor labels
+EDITOR_PATTERNS = {
+    "Editor:AmazonQ": [
+        r"src/promptrek/adapters/amazon_q\.py",
+        r"tests/.*test.*amazon.*q\.py",
+        r"examples/.*amazon.*q",
+        r"docs/.*amazon.*q",
+        r"\.amazonq/",
+    ],
+    "Editor:Cline": [
+        r"src/promptrek/adapters/cline\.py",
+        r"tests/.*test.*cline\.py",
+        r"examples/.*cline",
+        r"docs/.*cline",
+        r"\.clinerules/",
+    ],
+    "Editor:Kiro": [
+        r"src/promptrek/adapters/kiro\.py",
+        r"tests/.*test.*kiro\.py",
+        r"examples/.*kiro",
+        r"docs/.*kiro",
+        r"\.kiro/",
+    ],
+    "Editor:ClaudeCode": [
+        r"src/promptrek/adapters/claude\.py",
+        r"tests/.*test.*claude\.py",
+        r"examples/.*claude",
+        r"docs/.*claude",
+        r"\.claude/",
+    ],
+    "Editor:Continue": [
+        r"src/promptrek/adapters/continue",
+        r"tests/.*test.*continue",
+        r"examples/.*continue",
+        r"docs/.*continue",
+        r"\.continue/",
+    ],
+    "Editor:Copilot": [
+        r"src/promptrek/adapters/copilot\.py",
+        r"src/promptrek/templates/copilot/",
+        r"tests/.*test.*copilot",
+        r"examples/.*copilot",
+        r"docs/.*copilot",
+        r"\.github/copilot",
+    ],
+    "Editor:Windsurf": [
+        r"src/promptrek/adapters/windsurf\.py",
+        r"tests/.*test.*windsurf",
+        r"examples/.*windsurf",
+        r"docs/.*windsurf",
+        r"\.windsurf/",
+    ],
+    "Editor:JetBrainsAI": [
+        r"src/promptrek/adapters/jetbrains\.py",
+        r"tests/.*test.*jetbrains",
+        r"examples/.*jetbrains",
+        r"docs/.*jetbrains",
+        r"\.assistant/",
+    ],
+    "Editor:Cursor": [
+        r"src/promptrek/adapters/cursor\.py",
+        r"tests/.*test.*cursor",
+        r"examples/.*cursor",
+        r"docs/.*cursor",
+        r"\.cursor/",
+    ],
+}
+
+
+def determine_labels(changed_files: list[str]) -> Set[str]:
+    """
+    Determine which editor labels should be applied based on changed files.
+
+    Args:
+        changed_files: List of file paths that were changed in the PR
+
+    Returns:
+        Set of label names to apply
+    """
+    labels = set()
+
+    for file_path in changed_files:
+        # Normalize path separators
+        normalized_path = file_path.replace("\\", "/")
+
+        # Check each editor pattern
+        for label, patterns in EDITOR_PATTERNS.items():
+            for pattern in patterns:
+                if re.search(pattern, normalized_path, re.IGNORECASE):
+                    labels.add(label)
+                    break  # Found a match for this editor, move to next
+
+    return labels
+
+
+def main():
+    """Main entry point for the script."""
+    if len(sys.argv) < 2:
+        print("Usage: determine_labels.py <comma-separated-file-list>", file=sys.stderr)
+        sys.exit(1)
+
+    # Get changed files from command line argument
+    files_arg = sys.argv[1]
+    changed_files = [f.strip() for f in files_arg.split(",") if f.strip()]
+
+    if not changed_files:
+        print("No changed files provided", file=sys.stderr)
+        # Set empty output for GitHub Actions
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write("labels=\n")
+        sys.exit(0)
+
+    # Determine labels
+    labels = determine_labels(changed_files)
+
+    # Output for debugging
+    print(f"Changed files: {len(changed_files)}", file=sys.stderr)
+    print(f"Detected labels: {', '.join(sorted(labels)) if labels else 'none'}", file=sys.stderr)
+
+    # Set output for GitHub Actions
+    labels_str = ",".join(sorted(labels))
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"labels={labels_str}\n")
+    else:
+        # For local testing
+        print(f"Labels: {labels_str}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_determine_labels.py
+++ b/.github/scripts/test_determine_labels.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the determine_labels.py script.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the script directory to the path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from determine_labels import determine_labels
+
+
+def test_adapter_files():
+    """Test that adapter files are correctly labeled."""
+    files = [
+        "src/promptrek/adapters/cline.py",
+        "src/promptrek/adapters/claude.py",
+        "src/promptrek/adapters/cursor.py",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Cline" in labels
+    assert "Editor:ClaudeCode" in labels
+    assert "Editor:Cursor" in labels
+    assert len(labels) == 3
+
+
+def test_test_files():
+    """Test that test files are correctly labeled."""
+    files = [
+        "tests/unit/adapters/test_cline.py",
+        "tests/unit/adapters/test_claude.py",
+        "tests/unit/adapters/test_cursor_comprehensive.py",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Cline" in labels
+    assert "Editor:ClaudeCode" in labels
+    assert "Editor:Cursor" in labels
+
+
+def test_editor_directories():
+    """Test that editor-specific directories are correctly labeled."""
+    files = [
+        ".claude/agents/test.md",
+        ".continue/config.yaml",
+        ".cursor/rules/index.mdc",
+        ".windsurf/rules/example.md",
+        ".clinerules/custom.md",
+        ".kiro/steering/guide.md",
+        ".amazonq/rules/rules.md",
+        ".assistant/rules/jetbrains.md",
+        ".github/copilot-instructions.md",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:ClaudeCode" in labels
+    assert "Editor:Continue" in labels
+    assert "Editor:Cursor" in labels
+    assert "Editor:Windsurf" in labels
+    assert "Editor:Cline" in labels
+    assert "Editor:Kiro" in labels
+    assert "Editor:AmazonQ" in labels
+    assert "Editor:JetBrainsAI" in labels
+    assert "Editor:Copilot" in labels
+
+
+def test_documentation_files():
+    """Test that documentation files are correctly labeled."""
+    files = [
+        "docs/editors/cline.md",
+        "docs/adapters/claude-code.md",
+        "examples/advanced/cursor-example.yaml",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Cline" in labels
+    assert "Editor:ClaudeCode" in labels
+    assert "Editor:Cursor" in labels
+
+
+def test_non_editor_files():
+    """Test that non-editor files don't get labeled."""
+    files = [
+        "README.md",
+        "pyproject.toml",
+        "src/promptrek/core/parser.py",
+        "tests/unit/core/test_validator.py",
+    ]
+    labels = determine_labels(files)
+    assert len(labels) == 0
+
+
+def test_mixed_files():
+    """Test a mix of editor and non-editor files."""
+    files = [
+        "src/promptrek/adapters/amazon_q.py",
+        "README.md",
+        "tests/unit/adapters/test_windsurf.py",
+        "pyproject.toml",
+        ".continue/config.yaml",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:AmazonQ" in labels
+    assert "Editor:Windsurf" in labels
+    assert "Editor:Continue" in labels
+    assert len(labels) == 3
+
+
+def test_case_insensitive():
+    """Test that pattern matching is case-insensitive."""
+    files = [
+        "src/promptrek/adapters/CLINE.py",  # Unlikely but should still match
+        "TESTS/unit/adapters/test_claude.py",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Cline" in labels
+    assert "Editor:ClaudeCode" in labels
+
+
+def test_continue_adapter_variations():
+    """Test that Continue adapter file variations are matched."""
+    files = [
+        "src/promptrek/adapters/continue_adapter.py",
+        "tests/unit/adapters/test_continue_comprehensive.py",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Continue" in labels
+
+
+def test_copilot_template():
+    """Test that Copilot template files are labeled."""
+    files = [
+        "src/promptrek/templates/copilot/instructions.md.j2",
+    ]
+    labels = determine_labels(files)
+    assert "Editor:Copilot" in labels
+
+
+def test_all_editors():
+    """Test that we can detect all editor types."""
+    files = [
+        "src/promptrek/adapters/amazon_q.py",
+        "src/promptrek/adapters/cline.py",
+        "src/promptrek/adapters/kiro.py",
+        "src/promptrek/adapters/claude.py",
+        "src/promptrek/adapters/continue_adapter.py",
+        "src/promptrek/adapters/copilot.py",
+        "src/promptrek/adapters/windsurf.py",
+        "src/promptrek/adapters/jetbrains.py",
+        "src/promptrek/adapters/cursor.py",
+    ]
+    labels = determine_labels(files)
+    expected_labels = {
+        "Editor:AmazonQ",
+        "Editor:Cline",
+        "Editor:Kiro",
+        "Editor:ClaudeCode",
+        "Editor:Continue",
+        "Editor:Copilot",
+        "Editor:Windsurf",
+        "Editor:JetBrainsAI",
+        "Editor:Cursor",
+    }
+    assert labels == expected_labels
+
+
+if __name__ == "__main__":
+    # Run all tests
+    test_functions = [
+        test_adapter_files,
+        test_test_files,
+        test_editor_directories,
+        test_documentation_files,
+        test_non_editor_files,
+        test_mixed_files,
+        test_case_insensitive,
+        test_continue_adapter_variations,
+        test_copilot_template,
+        test_all_editors,
+    ]
+
+    print("Running tests for determine_labels.py...")
+    failed = []
+
+    for test_func in test_functions:
+        try:
+            test_func()
+            print(f"✓ {test_func.__name__}")
+        except AssertionError as e:
+            print(f"✗ {test_func.__name__}: {e}")
+            failed.append(test_func.__name__)
+        except Exception as e:
+            print(f"✗ {test_func.__name__}: Unexpected error: {e}")
+            failed.append(test_func.__name__)
+
+    print(f"\n{len(test_functions) - len(failed)}/{len(test_functions)} tests passed")
+
+    if failed:
+        print(f"\nFailed tests: {', '.join(failed)}")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed!")
+        sys.exit(0)

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,131 @@
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          separator: ","
+
+      - name: Determine labels
+        id: determine-labels
+        run: |
+          python .github/scripts/determine_labels.py "${{ steps.changed-files.outputs.all_changed_files }}"
+
+      - name: Apply labels
+        if: steps.determine-labels.outputs.labels != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = '${{ steps.determine-labels.outputs.labels }}'.split(',').filter(Boolean);
+
+            if (labels.length === 0) {
+              console.log('No labels to apply');
+              return;
+            }
+
+            console.log(`Applying labels: ${labels.join(', ')}`);
+
+            // Get existing labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const currentLabelNames = currentLabels.map(l => l.name);
+            const editorLabels = currentLabelNames.filter(l => l.startsWith('Editor:'));
+
+            // Remove old editor labels that are no longer relevant
+            const labelsToRemove = editorLabels.filter(l => !labels.includes(l));
+            for (const label of labelsToRemove) {
+              console.log(`Removing outdated label: ${label}`);
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label
+              }).catch(err => console.log(`Failed to remove ${label}: ${err.message}`));
+            }
+
+            // Add new labels
+            const labelsToAdd = labels.filter(l => !currentLabelNames.includes(l));
+            if (labelsToAdd.length > 0) {
+              console.log(`Adding labels: ${labelsToAdd.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labelsToAdd
+              });
+            }
+
+      - name: Comment on PR
+        if: steps.determine-labels.outputs.labels != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = '${{ steps.determine-labels.outputs.labels }}'.split(',').filter(Boolean);
+
+            if (labels.length === 0) return;
+
+            const editorList = labels.map(l => `- **${l.replace('Editor:', '')}**`).join('\n');
+
+            const body = `## Auto-Labeling Complete
+
+            This PR has been automatically labeled based on the files changed:
+
+            ${editorList}
+
+            These labels help us track which editors are impacted by this change.`;
+
+            // Check if we already commented
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('Auto-Labeling Complete')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }


### PR DESCRIPTION
This commit adds a GitHub Action workflow that automatically labels PRs based on the files that were changed. The workflow analyzes modified files and applies appropriate Editor:* labels to help track which editors are impacted by each change.

Features:
- Auto-labels PRs when opened, synchronized, or reopened
- Detects changes to adapter files, tests, docs, and editor-specific directories
- Applies labels: Editor:AmazonQ, Editor:Cline, Editor:Kiro, Editor:ClaudeCode, Editor:Continue, Editor:Copilot, Editor:Windsurf, Editor:JetBrainsAI, Editor:Cursor
- Removes outdated labels when files are no longer changed
- Posts a comment on the PR summarizing the applied labels
- Includes comprehensive test suite for the labeling logic

Files added:
- .github/workflows/auto-label.yml: GitHub Action workflow
- .github/scripts/determine_labels.py: Label detection script
- .github/scripts/test_determine_labels.py: Test suite
