### PR TITLE
Update PR Validation Summary on Test Failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -264,15 +264,15 @@ jobs:
             for (const comment of validationComments) {
               try {
                 await github.graphql(`
-                  mutation {
+                  mutation MinimizeComment($subjectId: ID!) {
                     minimizeComment(input: {
-                      subjectId: "${comment.node_id}",
+                      subjectId: $subjectId,
                       classifier: RESOLVED
                     }) {
                       clientMutationId
                     }
                   }
-                `);
+                `, { subjectId: comment.node_id });
                 console.log(`Minimized previous validation comment ${comment.id}`);
               } catch (error) {
                 console.log(`Failed to minimize comment ${comment.id}: ${error.message}`);


### PR DESCRIPTION
Updated the PR validation workflow to automatically minimize (hide as resolved) previous PR Validation Summary comments when new validation runs complete.

This ensures that:
- When tests fail: Old validation comments are hidden, new failure comment is posted
- When tests pass: Old validation comments are hidden, no new comment is posted

Uses GitHub's GraphQL API to minimize comments with RESOLVED classifier, which provides a clean PR comment thread and reduces confusion about which validation results are current.
