### PR TITLE
Fix mobile menu not opening on PrompTrek

### DIFF
--- a/gh-pages/assets/css/style.scss
+++ b/gh-pages/assets/css/style.scss
@@ -435,7 +435,7 @@ html, body {
     backdrop-filter: blur(10px);
   }
 
-  .nav-trigger:checked + label + .trigger {
+  .site-nav .nav-trigger:checked ~ .trigger {
     display: flex;
   }
 


### PR DESCRIPTION
The mobile menu wasn't working because the CSS selector wasn't properly scoped to .site-nav. Changed from `.nav-trigger:checked + label + .trigger` to `.site-nav .nav-trigger:checked ~ .trigger` to ensure the checkbox toggle correctly shows/hides the mobile menu.
