### PR TITLE
Fix hamburger menu on mobile site

### DIFF
--- a/gh-pages/assets/css/style.scss
+++ b/gh-pages/assets/css/style.scss
@@ -514,12 +514,17 @@ html, body {
   }
 
   .site-nav .trigger {
+    display: none;
     min-width: 160px;
     right: 0;
     padding: 0.5rem;
     background: #ffffff !important;
     border: 1px solid #e2e8f0 !important;
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
+  }
+
+  .site-nav .nav-trigger:checked ~ .trigger {
+    display: flex;
   }
 
   .site-nav .page-link {


### PR DESCRIPTION
The hamburger menu wasn't working on mobile screens 480px and below because the CSS rule for showing the menu when checked was only present in the 768px media query, not the 480px media query. Added the missing rule to ensure the menu appears when the hamburger is clicked on all mobile screen sizes.

Fixes the issue where clicking the hamburger icon had no effect on smaller mobile devices.
