### PR TITLE
Fix typewriter function error

### DIFF
--- a/gh-pages/_includes/head.html
+++ b/gh-pages/_includes/head.html
@@ -19,6 +19,12 @@
 
       promptLines.forEach((line, index) => {
         const text = line.getAttribute('data-text');
+
+        // Skip if no text attribute is present
+        if (!text) {
+          return;
+        }
+
         let displayText = '';
         let charIndex = 0;
 


### PR DESCRIPTION
Add validation to check if data-text attribute exists before attempting to use it in the typeWriter function. This prevents errors when elements with .prompt-line class don't have the required data-text attribute.
