### PR TITLE
fix: Make GitHub Action PR labeling more specific

### DIFF
--- a/.github/scripts/determine_labels.py
+++ b/.github/scripts/determine_labels.py
@@ -37,9 +37,9 @@ EDITOR_PATTERNS = {
     "Editor:ClaudeCode": [
         r"src/promptrek/adapters/claude\.py",
         r"tests/.*test.*claude\.py",
+        r"tests/.*test.*claude_",
         r"examples/.*claude",
         r"docs/.*claude",
-        r"\.claude/",
     ],
     "Editor:Continue": [
         r"src/promptrek/adapters/continue",
@@ -76,6 +76,19 @@ EDITOR_PATTERNS = {
         r"examples/.*cursor",
         r"docs/.*cursor",
         r"\.cursor/",
+    ],
+    "Schema:UPF": [
+        r"src/promptrek/core/models\.py",
+        r"src/promptrek/core/parser\.py",
+        r"src/promptrek/core/validator\.py",
+        r"scripts/generate_schemas\.py",
+        r"scripts/generate_v31_schema\.py",
+        r"scripts/test_schemas\.py",
+        r"gh-pages/schema/.*\.json",
+        r"gh-pages/user-guide/upf-specification\.md",
+        r"tests/.*test.*models\.py",
+        r"tests/.*test.*parser\.py",
+        r"tests/.*test.*validator\.py",
     ],
 }
 

--- a/.github/scripts/determine_labels.py
+++ b/.github/scripts/determine_labels.py
@@ -37,7 +37,7 @@ EDITOR_PATTERNS = {
     "Editor:ClaudeCode": [
         r"src/promptrek/adapters/claude\.py",
         r"tests/.*test.*claude\.py",
-        r"tests/.*test.*claude_",
+        r"tests/.*test.*claude_.*\.py",
         r"examples/.*claude",
         r"docs/.*claude",
     ],

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -98,7 +98,7 @@ jobs:
 
             ${editorList}
 
-            These labels help us track which editors are impacted by this change.`;
+            These labels help us track which editors and components are impacted by this change.`;
 
             // Check if we already commented
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
- Fixed ClaudeCode label to only trigger for Claude adapter changes (removed overly broad `.claude/` pattern that matched any file in that directory)
- Added Schema:UPF label to track changes to UPF schema components:
  - Core models, parser, and validator
  - Schema generation scripts
  - Schema JSON files
  - UPF specification documentation
- Updated workflow comment to reflect labeling of both editors and components

Fixes issue where PR #114 was incorrectly labeled as ClaudeCode when it only contained UPF schema changes.
